### PR TITLE
Support RunWhen Public Locations

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.5.8"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -197,6 +197,9 @@ runner:
 # grafana-agent is only deployed if runner.enabled is true
 # https://github.com/grafana/agent/blob/main/operations/helm/charts/grafana-agent/values.yaml
 grafana-agent:
+  crds:
+    # -- Whether to install CRDs for monitoring.
+    create: false
   agent:
     mode: 'flow'
     configMap:


### PR DESCRIPTION
- disables grafana-agent CRDs by default when rolling out the runner. I suspect this is probably a good default unless they're required for the agent in our current use case. If they are then we can default to true and only disable them for public locations.