### PR TITLE
Add/fargate-option

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.1.4
-appVersion: "0.5.8"
+version: 0.1.5
+appVersion: "0.5.10"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   - name: grafana-agent

--- a/charts/runwhen-local/templates/local-configmap.yaml
+++ b/charts/runwhen-local/templates/local-configmap.yaml
@@ -10,6 +10,8 @@ data:
     defaultLocation: {{ .Values.runwhenLocal.workspaceInfo.configMap.data.defaultLocation | default "none" }}
     workspaceOwnerEmail: {{ .Values.runwhenLocal.workspaceInfo.configMap.data.workspaceOwnerEmail | default "tester@mycompany.com" }}
     defaultLOD: {{ .Values.runwhenLocal.workspaceInfo.configMap.data.defaultLOD | default "detailed" }}
+    codeCollections:
+      {{- toYaml .Values.runwhenLocal.workspaceInfo.configMap.data.codeCollections | nindent 6 }}
     cloudConfig:
       {{- toYaml .Values.runwhenLocal.workspaceInfo.configMap.data.cloudConfig | nindent 6 }}
     custom:

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -66,7 +66,11 @@ spec:
             periodSeconds: 5
             failureThreshold: 5
           resources:
-            {{- toYaml .Values.runwhenLocal.resources | nindent 12 }}
+            {{- if eq .Values.platformType "EKS_Fargate" }}
+            {{- toYaml .Values.runwhenLocal.resources.EKS_Fargate | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.runwhenLocal.resources.default | nindent 12 }}
+            {{- end }}
           volumeMounts:
           - name: shared-volume
             mountPath: "/shared"

--- a/charts/runwhen-local/templates/runner-deployment.yaml
+++ b/charts/runwhen-local/templates/runner-deployment.yaml
@@ -33,7 +33,12 @@ spec:
         - containerPort: 9090
           name: metrics
           protocol: TCP
-        resources: {}
+        resources:
+          {{- if eq .Values.platformType "EKS_Fargate" }}
+          {{- toYaml .Values.runner.resources.EKS_Fargate | nindent 12 }}
+          {{- else }}
+          {{- toYaml .Values.runner.resources.default | nindent 12 }}
+          {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         env:

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -33,6 +33,11 @@ tolerations: []
 
 affinity: {}
 
+# Is this a platform the requires special configuration?
+# Currently supports EKS_Fargate, kubernetes
+platformType: "kubernetes" 
+
+
 ###############################################################################
 ######################## RunWhen Local Configuration ##########################
 ###############################################################################
@@ -95,12 +100,21 @@ runwhenLocal:
     #      - chart-example.local
 
   resources:
-    requests:
-      memory: "256Mi"
-      cpu: "250m"
-    limits:
-      memory: "1024Mi"
-      cpu: "1"
+    default:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "1"
+        memory: "1024Mi"
+    EKS_Fargate:
+      requests:
+        cpu: "2"  
+        memory: "1024Mi"
+      limits:
+        cpu: "2"
+        memory: "1024Mi"
+
 
   # RunWhen Local requires a kubeconfig to discover resouces from 1 or more
   # clusters.
@@ -175,6 +189,7 @@ runwhenLocal:
               kube-system: 0
               kube-public: 0
               kube-node-lease: 0
+        codeCollections: []
         custom:
           kubeconfig_secret_name: kubeconfig
           kubernetes_distribution_binary: kubectl
@@ -193,6 +208,21 @@ runner:
   controlAddr: "https://runner.beta.runwhen.com"
   metrics:
     url: "https://runner-cortex-tenant.beta.runwhen.com/push"
+  resources:
+    default:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "200m"
+        memory: "256Mi"
+    EKS_Fargate:
+      requests:
+        cpu: "200m"
+        memory: "256Mi"
+      limits:
+        cpu: "200m"
+        memory: "256Mi"
 
 # grafana-agent is only deployed if runner.enabled is true
 # https://github.com/grafana/agent/blob/main/operations/helm/charts/grafana-agent/values.yaml

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -35,8 +35,7 @@ affinity: {}
 
 # Is this a platform the requires special configuration?
 # Currently supports EKS_Fargate, kubernetes
-platformType: "kubernetes" 
-
+platformType: "kubernetes"
 
 ###############################################################################
 ######################## RunWhen Local Configuration ##########################
@@ -109,7 +108,7 @@ runwhenLocal:
         memory: "1024Mi"
     EKS_Fargate:
       requests:
-        cpu: "2"  
+        cpu: "2"
         memory: "1024Mi"
       limits:
         cpu: "2"


### PR DESCRIPTION
Adds an option to define a platform type. Currently only supports EKS_fargate, which will set different resource requirements bsaed on the needs of that platform. 