### PR TITLE
feat(runner): support additional configuration options

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.5.10"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -45,6 +45,20 @@ spec:
           - name: DEBUG_LOGGING
             value: "true"
           {{ end }}
+          {{- if .Values.proxy.enabled }}
+          {{- with .Values.proxy.httpProxy }}
+          - name: HTTP_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.proxy.httpsProxy }}
+          - name: HTTPS_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- with .Values.proxy.noProxy }}
+          - name: NO_PROXY
+            value: {{ . }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: mkdocs
               containerPort: 8081

--- a/charts/runwhen-local/templates/runner-configmap.yaml
+++ b/charts/runwhen-local/templates/runner-configmap.yaml
@@ -16,9 +16,10 @@ data:
     {{- toYaml .Values.runner.configMap.raw | nindent 4 }}
     {{- else }}
     global:
+      {{- with .Values.runner.log }}
       log:
-        level: INFO
-        format: console
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       controlAddr: {{ .Values.runner.controlAddr }}
       metricsAddr: {{ .Values.runner.metrics.url }}
       proxy:

--- a/charts/runwhen-local/templates/runner-configmap.yaml
+++ b/charts/runwhen-local/templates/runner-configmap.yaml
@@ -23,10 +23,10 @@ data:
       controlAddr: {{ .Values.runner.controlAddr }}
       metricsAddr: {{ .Values.runner.metrics.url }}
       proxy:
-        enabled: {{ .Values.runner.proxy.enabled }}
-        httpProxy: "{{ .Values.runner.proxy.httpProxy }}"
-        httpsProxy: "{{ .Values.runner.proxy.httpsProxy }}"
-        noProxy:  "{{ .Values.runner.proxy.noProxy }}"
+        enabled: {{ .Values.proxy.enabled }}
+        httpProxy: "{{ .Values.proxy.httpProxy }}"
+        httpsProxy: "{{ .Values.proxy.httpsProxy }}"
+        noProxy:  "{{ .Values.proxy.noProxy }}"
     environment:
       {{- with .Values.runner.runEnvironment.blockedSecrets }}
       blockedSecrets:
@@ -42,11 +42,11 @@ data:
       {{- end }}
       kubernetes:
         proxy:
-          enabled: {{ or .Values.runner.runEnvironment.proxy.enabled .Values.runner.proxy.enabled }}
-          httpProxy: "{{ or .Values.runner.runEnvironment.proxy.httpProxy .Values.runner.proxy.httpProxy }}"
-          httpsProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.runner.proxy.httpProxy }}"
-          noProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.runner.proxy.httpProxy }}"
-          proxyCA: "{{ or .Values.runner.runEnvironment.proxy.proxyCA .Values.runner.proxy.httpProxy }}"
+          enabled: {{ or .Values.runner.runEnvironment.proxy.enabled .Values.proxy.enabled }}
+          httpProxy: "{{ or .Values.runner.runEnvironment.proxy.httpProxy .Values.proxy.httpProxy }}"
+          httpsProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.proxy.httpProxy }}"
+          noProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.proxy.httpProxy }}"
+          proxyCA: "{{ or .Values.runner.runEnvironment.proxy.proxyCA .Values.proxy.httpProxy }}"
         deployment:
           {{- with .Values.runner.runEnvironment.deployment.annotations }}
           annotations:

--- a/charts/runwhen-local/templates/runner-configmap.yaml
+++ b/charts/runwhen-local/templates/runner-configmap.yaml
@@ -1,0 +1,146 @@
+{{- if and .Values.runner.configMap .Values.runner.configMap.create -}}
+{{- $_ := .Values.runner.configMap.apiVersion | required ".Values.runner.configMap.apiVersion must be set !" -}}
+{{- $_ := .Values.runner.configMap.kind | required ".Values.runner.configMap.kind must be set !" -}}
+{{- $_ := .Values.runner.configMap.name | required ".Values.runner.configMap.name must be set !" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.runner.configMap.name }}
+  labels:
+    app: runner
+data:
+  config.yaml: |
+    apiVersion: {{ .Values.runner.configMap.apiVersion }}
+    kind: {{ .Values.runner.configMap.kind }}
+    {{- if .Values.runner.configMap.raw }}
+    {{- toYaml .Values.runner.configMap.raw | nindent 4 }}
+    {{- else }}
+    global:
+      log:
+        level: INFO
+        format: console
+      controlAddr: {{ .Values.runner.controlAddr }}
+      metricsAddr: {{ .Values.runner.metrics.url }}
+      proxy:
+        enabled: {{ .Values.runner.proxy.enabled }}
+        httpProxy: "{{ .Values.runner.proxy.httpProxy }}"
+        httpsProxy: "{{ .Values.runner.proxy.httpsProxy }}"
+        noProxy:  "{{ .Values.runner.proxy.noProxy }}"
+    environment:
+      {{- with .Values.runner.runEnvironment.blockedSecrets }}
+      blockedSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runner.runEnvironment.secretsProvided }}
+      secretsProvided:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runner.runEnvironment.secretProviders }}
+      secretProviders:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      kubernetes:
+        proxy:
+          enabled: {{ or .Values.runner.runEnvironment.proxy.enabled .Values.runner.proxy.enabled }}
+          httpProxy: "{{ or .Values.runner.runEnvironment.proxy.httpProxy .Values.runner.proxy.httpProxy }}"
+          httpsProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.runner.proxy.httpProxy }}"
+          noProxy: "{{ or .Values.runner.runEnvironment.proxy.httpsProxy .Values.runner.proxy.httpProxy }}"
+          proxyCA: "{{ or .Values.runner.runEnvironment.proxy.proxyCA .Values.runner.proxy.httpProxy }}"
+        deployment:
+          {{- with .Values.runner.runEnvironment.deployment.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.deployment.podAnnotations }}
+          podAnnotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.deployment.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.deployment.nodeName }}
+          nodeName: {{ . }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.deployment.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.extraEnv }}
+          envVars:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- if eq .Values.platformType "EKS_Fargate" }}
+            {{- toYaml .Values.runner.runEnvironment.deployment.resources.EKS_Fargate | nindent 12 }}
+          {{- else }}
+            {{- toYaml .Values.runner.runEnvironment.deployment.resources.default | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.securityContext }}
+          podSecurityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.deployment.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        pod:
+          {{- with .Values.runner.runEnvironment.pod.annotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.pod.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.pod.nodeName }}
+          nodeName: {{ . }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.pod.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.extraEnv }}
+          envVars:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+          {{- if eq .Values.platformType "EKS_Fargate" }}
+            {{- toYaml .Values.runner.runEnvironment.pod.resources.EKS_Fargate | nindent 12 }}
+          {{- else }}
+            {{- toYaml .Values.runner.runEnvironment.pod.resources.default | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.securityContext }}
+          podSecurityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.pod.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.runner.runEnvironment.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+    {{- end }}
+{{- end -}}

--- a/charts/runwhen-local/templates/runner-deployment.yaml
+++ b/charts/runwhen-local/templates/runner-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - image: {{ .Values.runner.image | default "us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:stable" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.runner.imagePullPolicy | default "IfNotPresent" }}
         name: runner
         ports:
         - containerPort: 9090

--- a/charts/runwhen-local/templates/runner-deployment.yaml
+++ b/charts/runwhen-local/templates/runner-deployment.yaml
@@ -41,9 +41,14 @@ spec:
           {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        volumeMounts:
+        - name: runner-config-volume
+          mountPath: "/etc/runwhen/runner/config.yaml"
+          subPath: "config.yaml"
+        {{- with .Values.runner.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         env:
-        - name: RW_WORKSPACE
-          value: "{{ include "runwhen-local.workspaceName" . }}"
         - name: RUNNER_CONTROL_ADDR
           value: "{{ .Values.runner.controlAddr | default "https://runner.beta.runwhen.com" }}"
         - name: RUNNER_NAMESPACE
@@ -51,13 +56,33 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+        {{- if .Values.runner.proxy.enabled }}
+        {{- with .Values.runner.proxy.httpProxy }}
+        - name: HTTP_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.runner.proxy.httpsProxy }}
+        - name: HTTPS_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- with .Values.runner.proxy.noProxy }}
+        - name: NO_PROXY
+          value: {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.runner.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.runner.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: runner
       serviceAccountName: runner
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 50
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -68,6 +93,17 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.runner.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: runner-config-volume
+        configMap:
+          name: {{ .Values.runner.configMap.name }}
+      {{ with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/runwhen-local/templates/runner-deployment.yaml
+++ b/charts/runwhen-local/templates/runner-deployment.yaml
@@ -56,16 +56,16 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        {{- if .Values.runner.proxy.enabled }}
-        {{- with .Values.runner.proxy.httpProxy }}
+        {{- if .Values.proxy.enabled }}
+        {{- with .Values.proxy.httpProxy }}
         - name: HTTP_PROXY
           value: {{ . }}
         {{- end }}
-        {{- with .Values.runner.proxy.httpsProxy }}
+        {{- with .Values.proxy.httpsProxy }}
         - name: HTTPS_PROXY
           value: {{ . }}
         {{- end }}
-        {{- with .Values.runner.proxy.noProxy }}
+        {{- with .Values.proxy.noProxy }}
         - name: NO_PROXY
           value: {{ . }}
         {{- end }}

--- a/charts/runwhen-local/templates/runner-grafana-agent-configmap.yaml
+++ b/charts/runwhen-local/templates/runner-grafana-agent-configmap.yaml
@@ -24,6 +24,14 @@ data:
     prometheus.remote_write "runwhen" {
         endpoint {
             url = "{{ .Values.runner.metrics.url }}"
+            {{- if .Values.proxy.enabled }}
+            {{- with .Values.proxy.httpsProxy }}
+            proxy_url =  "{{ . }}"
+            {{- end }}
+            {{- with .Values.proxy.noProxy }}
+            no_proxy = "{{ . }}"
+            {{- end }}
+            {{- end }}
             tls_config {
             ca_file = "/tls/ca.crt"
             cert_file = "/tls/tls.crt"

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -211,17 +211,172 @@ runwhenLocal:
 
 runner:
   enabled: false
+
+  log:
+    level: info
+    format: console
+
+  configMap:
+    create: true
+    name: runner-config
+    apiVersion: config.runwhen.com/v1
+    kind: RunnerConfig
+    raw: {}
+
   image: "us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:latest"
   controlAddr: "https://runner.beta.runwhen.com"
   metrics:
     url: "https://runner-cortex-tenant.beta.runwhen.com/push"
+
+  # securityContext (container) is used to set the security context for the runner container
+  securityContext: {}
+
+  # securityContext is used to set the security context for the runner pod
+  podSecurityContext: {}
+
+  # Extra environment variables for the runner container
+  extraEnv: {}
+
+  # Extra volumes for the runner container
+  volumes: {}
+
+  # Extra volume mounts for the runner container
+  volumeMounts: {}
+
+  ## The target environments configuration for deploying the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+  runEnvironment:
+    # volumes common for all the pods created by the runner
+    volumes: {}
+
+    # volumeMounts common for all the pods created by the runner
+    volumeMounts: {}
+
+    # extraEnv is used to add additional environment variables for the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    extraEnv: {}
+
+    # containerSecurityContext is used to set the security context for both the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    securityContext: {}
+
+    # securityContext is used to set the security context for both the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    podSecurityContext: {}
+
+    secretProviders: {}
+      # mycustomprovider:
+      #   description: "A description of the secret provider using the VaultSecretProvider with AppRole Auth"
+      #   type: vault
+      #   vaultSecretProvider:
+      #     addr: "https://vault.superfake.runwhen.com"
+      #     authMountPath: "dev" # /auth/$authMountPath/login
+      #     roleID:
+      #       kubernetes:
+      #         secret:
+      #           name: vault-secret
+      #           key: role-id
+      #     secretID:
+      #       kubernetes:
+      #         secret:
+      #           name: vault-secret
+      #           key: secret-id
+
+    # secretsProvided is used to mount the secrets to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    # The secrets are mounted as files or environment variables and much come from either a built in provider or a custom provider
+    #
+    # The built in providers and the format of their secrets provided entries are as follows:
+    # Built In Providers Supported:
+    # 1. Provider: k8s:file - Kubernetes Secret or ConfigMap Field loaded as a file
+    #    Format: <codeKey>: "k8s:file@<kind>/<name>:<field>"
+    # 2. Provider: k8s:env - Kubernetes Secret or ConfigMap Field loaded as an environment variable
+    #    Format: <codeKey>: "k8s:env@<kind>/<name>:<field>"
+    #
+    # Custom Providers Supported: Added through .Values.runner.runEnvironment.SecretProviders
+    # 1. Provider: <your-provider> Type: vault - Vault Secret loaded at use time
+    #    Format: <codeKey>: "<your-secret-provider-name>@<path/data/to/secret>:<field>"
+    #    Note: The path is the path to the secret in the vault including `/data/` assuming kv-v2
+    # Note: The generic format is <codeKey>: "<provider-name>@<path/deliminated/options>:<field>"
+    secretsProvided: {}
+      # kubeconfig: "k8s:file@secret/my-kubeconfig:kubeconfig-key-in-secret"
+      # someConfig: "k8s:file@configmap/my-cm:key-in-cm"
+      # hello: "k8s:env@secret/my-secret:hello"
+      # vaultSecret: "my-vault@/dev/data/simple-test-secret:hello"
+
+    # blockedSecrets is used to block secrets from being mounted to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    # The format of the blockedSecrets entries are as follows:
+    # - "<provider-name>@<some optional path>:<optional field>"
+    blockedSecrets: []
+    # Block the use of all k8s secrets/configmaps being mounted to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    # - "k8s:file@"
+    # Block the use of all k8s secrets/configmaps being mounted as environment variables to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    # - "k8s:env@"
+    # Block the use of a specific secret being mounted to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
+    # - "myvault@/dev/data/simple-test-secret"
+
+    # The configurations exposed the SLI (CronCodeRun) Deployments
+    deployment:
+      annotations: {}
+      podAnnotations: {}
+      affinity: {}
+      nodeName: ""
+      nodeSelector: {}
+      tolerations: []
+      resources:
+        default:
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+          limits:
+            cpu: "300m"
+            memory: "196Mi"
+        EKS_Fargate:
+          requests:
+            cpu: "300m"
+            memory: "196Mi"
+          limits:
+            cpu: "300m"
+            memory: "196Mi"
+    # The configurations exposed the TaskSet (CodeRun) Pods
+    pod:
+      annotations: {}
+      affinity: {}
+      nodeName: ""
+      nodeSelector: {}
+      tolerations: []
+      resources:
+        default:
+          requests:
+            cpu: "50m"
+            memory: "128Mi"
+          limits:
+            cpu: "300m"
+            memory: "256Mi"
+        EKS_Fargate:
+          requests:
+            cpu: "300m"
+            memory: "64Mi"
+          limits:
+            cpu: "300m"
+            memory: "256Mi"
+    proxy: 
+      enabled: false
+      httpProxy: ""
+      httpsProxy: ""
+      noProxy: ""
+      proxyCA: ""
+
+  # proxy configuration for the runner container, set runEnvironment.proxy.enabled to true to use this configuration
+  # fo the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods as well, or configure custom proxy settings in the runEnvironment
+  proxy:
+    enabled: false
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""
+    proxyCA: ""
   resources:
     default:
       requests:
-        cpu: "50m"
+        cpu: "200m"
         memory: "64Mi"
       limits:
-        cpu: "200m"
+        cpu: "800m"
         memory: "256Mi"
     EKS_Fargate:
       requests:

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -279,7 +279,7 @@ runner:
       #           key: secret-id
 
     # secretsProvided is used to mount the secrets to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
-    # The secrets are mounted as files or environment variables and much come from either a built in provider or a custom provider
+    # The secrets are mounted as files or environment variables and must come from either a built in provider or a custom provider
     #
     # The built in providers and the format of their secrets provided entries are as follows:
     # Built In Providers Supported:
@@ -310,7 +310,7 @@ runner:
     # Block the use of a specific secret being mounted to the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods
     # - "myvault@/dev/data/simple-test-secret"
 
-    # The configurations exposed the SLI (CronCodeRun) Deployments
+    # The configurations applied to the SLI (CronCodeRun) Deployments
     deployment:
       annotations: {}
       podAnnotations: {}
@@ -333,7 +333,7 @@ runner:
           limits:
             cpu: "300m"
             memory: "196Mi"
-    # The configurations exposed the TaskSet (CodeRun) Pods
+    # The configurations applired to the TaskSet (CodeRun) Pods
     pod:
       annotations: {}
       affinity: {}
@@ -363,7 +363,7 @@ runner:
       proxyCA: ""
 
   # proxy configuration for the runner container, set runEnvironment.proxy.enabled to true to use this configuration
-  # fo the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods as well, or configure custom proxy settings in the runEnvironment
+  # for the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods as well, or configure custom proxy settings in the runEnvironment.proxy fields
   proxy:
     enabled: false
     httpProxy: ""

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -33,6 +33,14 @@ tolerations: []
 
 affinity: {}
 
+# Set proxy details for the runner & runwhenLocal deployments
+proxy:
+  enabled: false
+  httpProxy: ""
+  httpsProxy: ""
+  noProxy: ""
+  proxyCA: ""
+
 # Is this a platform the requires special configuration?
 # Currently supports EKS_Fargate, kubernetes
 platformType: "kubernetes"
@@ -355,7 +363,7 @@ runner:
           limits:
             cpu: "300m"
             memory: "256Mi"
-    proxy: 
+    proxy:
       enabled: false
       httpProxy: ""
       httpsProxy: ""
@@ -364,12 +372,6 @@ runner:
 
   # proxy configuration for the runner container, set runEnvironment.proxy.enabled to true to use this configuration
   # for the SLI (CronCodeRun) Deployments and TaskSet (CodeRun) Pods as well, or configure custom proxy settings in the runEnvironment.proxy fields
-  proxy:
-    enabled: false
-    httpProxy: ""
-    httpsProxy: ""
-    noProxy: ""
-    proxyCA: ""
   resources:
     default:
       requests:


### PR DESCRIPTION
This has been tested with the latest runner image (`latest` and `2024-05-03.1`), and while not the nicest-looking values file, it'll do the job. Everything required is set so a standalone runner will deploy without issue. Existing runners on old helm chart versions using the latest runner image are also backwards compatible if the image is repelled. There's a fallback config with defaults baked into the image.

Suggestions welcome. 