### PR TITLE
Add/kubeconfig-secret-generation

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -3,7 +3,7 @@ name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
 version: 0.1.9
-appVersion: "0.5.10"
+appVersion: "0.5.12"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   - name: grafana-agent

--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.5.10"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -45,6 +45,8 @@ spec:
           - name: DEBUG_LOGGING
             value: "true"
           {{ end }}
+          - name: KUBERNETES_CLUSTER_NAME
+            value: {{ .Values.runwhenLocal.clusterName }}
           {{- if .Values.proxy.enabled }}
           {{- with .Values.proxy.httpProxy }}
           - name: HTTP_PROXY

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -45,6 +45,10 @@ spec:
           - name: DEBUG_LOGGING
             value: "true"
           {{ end }}
+          {{ if .Values.runwhenLocal.discoveryKubeconfig.inClusterAuth.createKubeconfigSecret }}
+          - name: RW_CREATE_KUBECONFIG_SECRET
+            value: "true"
+          {{ end }}
           - name: KUBERNETES_CLUSTER_NAME
             value: {{ .Values.runwhenLocal.clusterName }}
           {{- if .Values.proxy.enabled }}

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.runwhenLocal.serviceAccount.name }}
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/runwhen-local/templates/local-serviceaccount.yaml
+++ b/charts/runwhen-local/templates/local-serviceaccount.yaml
@@ -26,8 +26,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create"]
-  resourceNames: ["{{ .Values.runwhenLocal.serviceAccount.name }}-token"]
+  verbs: ["get", "update", "delete", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/runwhen-local/templates/local-serviceaccount.yaml
+++ b/charts/runwhen-local/templates/local-serviceaccount.yaml
@@ -22,21 +22,21 @@ type: kubernetes.io/service-account-token
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Values.runwhenLocal.serviceAccount.name }}-sa-secret-self-view
+  name: {{ .Values.runwhenLocal.serviceAccount.name }}-sa-secret-manage
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get"]
+  verbs: ["get", "create"]
   resourceNames: ["{{ .Values.runwhenLocal.serviceAccount.name }}-token"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Values.runwhenLocal.serviceAccount.name }}-a-secret-self-view-rb
+  name: {{ .Values.runwhenLocal.serviceAccount.name }}-a-secret-manage-rb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Values.runwhenLocal.serviceAccount.name }}-sa-secret-self-view
+  name: {{ .Values.runwhenLocal.serviceAccount.name }}-sa-secret-manage
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.runwhenLocal.serviceAccount.name }}

--- a/charts/runwhen-local/templates/local-serviceaccount.yaml
+++ b/charts/runwhen-local/templates/local-serviceaccount.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- with .Values.runwhenLocal.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+    kubernetes.io/service-account.token-expiration: "31536000"  # 1 year in seconds
   {{- end }}
 ---
 apiVersion: v1

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -134,6 +134,7 @@ runwhenLocal:
   discoveryKubeconfig:
     inClusterAuth:
       enabled: true
+      createKubeconfigSecret: true
     secretProvided:
       enabled: false
       # secretName: kubeconfig

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -203,7 +203,10 @@ runwhenLocal:
           # should be referenced from the platform. The secret itself (key and value)
           # must be created in the RunWhen Platform by the user. We do not upload
           # or configure secrets automatically.
-          kubeconfig_secret_name: kubeconfig
+          # The default for kubeconfig_secret_name is set to a secret that runwhenLocal
+          # creates for the use of the runner. This can be simply swapped out with the
+          # name of a secret that is stored in the RunWhen Platform.
+          kubeconfig_secret_name: "k8s:file@secret/kubeconfig:kubeconfig"
           kubernetes_distribution_binary: kubectl
           cloud_provider: none
           gcp_project_id: none

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -130,7 +130,7 @@ runwhenLocal:
   # If discovering multiple clusters, set inClusterAuth.enabled=false
   # and mount a secret with a kubeconfig that contains all
   # cluster contexts to be discovered
-
+  clusterName: "default"
   discoveryKubeconfig:
     inClusterAuth:
       enabled: true


### PR DESCRIPTION
defaults the workspaceInfo to use a locally generated kubeconfig secret instead of a platform provided secret. Has no effect for runwhenLocal specifically, but affects where the slis/tasksets load secrets from