### PR TITLE
add component level image override and global registry override

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.1.16
-appVersion: "0.5.16"
+version: 0.1.17
+appVersion: "0.5.17"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   - name: grafana-agent

--- a/charts/runwhen-local/templates/local-deployment.yaml
+++ b/charts/runwhen-local/templates/local-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.runwhenLocal.securityContext | nindent 12 }}
-          image: "{{ .Values.runwhenLocal.image.repository }}:{{ .Values.runwhenLocal.image.tag | default .Chart.AppVersion }}"
+          image: "{{ (.Values.runwhenLocal.image.registry | default .Values.registryOverride)| default "ghcr.io" }}/{{ .Values.runwhenLocal.image.repository | default "runwhen-contrib/runwhen-local" }}:{{ .Values.runwhenLocal.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.runwhenLocal.image.pullPolicy }}
           env: 
           - name: AUTORUN_WORKSPACE_BUILDER_INTERVAL

--- a/charts/runwhen-local/templates/runner-deployment.yaml
+++ b/charts/runwhen-local/templates/runner-deployment.yaml
@@ -26,7 +26,7 @@ spec:
       {{- end }}
     spec:
       containers:
-      - image: {{ .Values.runner.image | default "us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:stable" }}
+      - image: "{{ (.Values.runner.image.registry |  default .Values.registryOverride) | default "us-docker.pkg.dev" }}/{{ .Values.runner.image.repository | default "runwhen-nonprod-shared/public-images/runner" }}:{{ .Values.runner.image.tag | default "stable" }}"
         imagePullPolicy: {{ .Values.runner.imagePullPolicy | default "Always" }}
         name: runner
         ports:

--- a/charts/runwhen-local/templates/runner-push-gw.yaml
+++ b/charts/runwhen-local/templates/runner-push-gw.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: pushgateway
-        image: prom/pushgateway
+        image: "{{ (.Values.runner.pushgateway.image.registry | default .Values.registryOverride)| default "docker.io" }}/{{ .Values.runner.pushgateway.image.repository | default "prom/pushgateway" }}:{{ .Values.runner.pushgateway.image.tag | default "latest"}}"
         command: ["/bin/pushgateway"]
         args: ["--log.level=debug"]
         ports:

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -33,6 +33,10 @@ tolerations: []
 
 affinity: {}
 
+# Override the container image registry used for all images
+# Note: grafana-agent is a subchart and must still be explicitly updated.
+registryOverride: ""
+
 # Set proxy env for RunWhen Local and Runner Deployments and any supporting infrastructure such as the grafana-agent
 proxy:
   enabled: false
@@ -63,7 +67,8 @@ platformType: "kubernetes"
 runwhenLocal:
   enabled: true
   image:
-    repository: ghcr.io/runwhen-contrib/runwhen-local
+    registry: ""
+    repository: ""
     pullPolicy: Always
     # Overrides the image tag whose default is the chart appVersion.
     tag: "latest"
@@ -250,7 +255,10 @@ runner:
     kind: RunnerConfig
     raw: {}
 
-  image: "us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:latest"
+  image:
+    registry: ""
+    repository: ""
+    tag: "latest"
   controlAddr: "https://runner.beta.runwhen.com"
   metrics:
     url: "https://runner-cortex-tenant.beta.runwhen.com/push"
@@ -414,12 +422,23 @@ runner:
         cpu: "200m"
         memory: "256Mi"
 
+  ## Override the Prometheus Pushgateway settings
+  pushgateway:
+    image:
+      registry: ""
+      repository: ""
+      tag: ""
+
 # grafana-agent is only deployed if runner.enabled is true
 # https://github.com/grafana/agent/blob/main/operations/helm/charts/grafana-agent/values.yaml
 grafana-agent:
   crds:
     # -- Whether to install CRDs for monitoring.
     create: false
+  image:
+    registry: "docker.io"
+    repository: "grafana/agent"
+    tag: ""
   agent:
     enableReporting: false
     mode: 'flow'


### PR DESCRIPTION
Fixes https://github.com/runwhen-contrib/helm-charts/issues/23

Add's the global registryOverride.  
Adds image registry and repository customization at the component level. 
Adds grafana-agent sub chart image configuration. 