### PR TITLE
pin versions

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runwhen-local
 description: A Helm chart RunWhen Local - A community powered troubleshooting cheat sheet
 type: application
-version: 0.2.6
-appVersion: "0.8.0"
+version: 0.2.7
+appVersion: "0.8.1"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   # - name: grafana-agent

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -439,7 +439,7 @@ runner:
     image:
       registry: ""
       repository: ""
-      tag: ""
+      tag: "v1.10.0"
     tolerations: []
 
 ## opentelemetry-collector is only deployed if runner.enabled is true
@@ -452,7 +452,7 @@ opentelemetry-collector:
   image:
     repository: "otel/opentelemetry-collector"
     pullPolicy: IfNotPresent
-    tag: "latest"
+    tag: "0.104.0"
   imagePullSecrets: []
   command:
     name: "otelcol"


### PR DESCRIPTION
By pinning docker versions in the values file, our update scripts won't exhaust the docker API limits. 