### PR TITLE
Update Pushgateway Version to v1.11.0

### DIFF
--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -439,7 +439,7 @@ runner:
     image:
       registry: ""
       repository: ""
-      tag: "v1.10.0"
+      tag: "v1.11.0"
     tolerations: []
 
 ## opentelemetry-collector is only deployed if runner.enabled is true


### PR DESCRIPTION
While the plan is to switch to a pure OTEL setup, if we need to roll the pushgateway in the interim or support both, this will resolve CVE-2024-45341 and CVE-2025-22866.