### PR TITLE
revert otel config #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ trivy image --severity CRITICAL,HIGH --ignore-unfixed --scanners vuln --format j
 Registry                                                                                                         Package                       Vulnerability ID  Installed Version                         Fixed Version                 Severity
 --------                                                                                                         -------                       ----------------  -----------------                         -------------                 --------
 ghcr.io/runwhen-contrib/runwhen-local:latest                                                                     stdlib                        CVE-2025-22874    v1.24.1                                   1.24.4                        HIGH
+otel/opentelemetry-collector:0.127.0                                                                             stdlib                        CVE-2025-22874    v1.24.3                                   1.24.4                        HIGH
 us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:latest                                             golang.org/x/oauth2           CVE-2025-22868    v0.24.0                                   0.27.0                        HIGH
 us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:latest                                             golang.org/x/crypto           CVE-2025-22869    v0.31.0                                   0.35.0                        HIGH
 us-west1-docker.pkg.dev/runwhen-nonprod-beta/public-images/runwhen-contrib-aws-c7n-codecollection-main:latest    golang.org/x/oauth2           CVE-2025-22868    v0.10.0                                   0.27.0                        HIGH
@@ -216,7 +217,7 @@ us-west1-docker.pkg.dev/runwhen-nonprod-beta/public-images/runwhen-contrib-azure
 ```
 
 ghcr.io/runwhen-contrib/runwhen-local:latest
-otel/opentelemetry-collector:0.130.1
+otel/opentelemetry-collector:0.127.0
 us-docker.pkg.dev/runwhen-nonprod-shared/public-images/runner:latest
 us-west1-docker.pkg.dev/runwhen-nonprod-beta/public-images/runwhen-contrib-aws-c7n-codecollection-main:latest
 us-west1-docker.pkg.dev/runwhen-nonprod-beta/public-images/runwhen-contrib-azure-c7n-codecollection-main:latest

--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: runwhen-local
 description: The RunWhen Local Helm Chart - Private runners powering Agentic AI
 type: application
-version: 0.4.7
+version: 0.4.8
 appVersion: "0.10.22"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -486,13 +486,12 @@ opentelemetry-collector:
   image:
     repository: "otel/opentelemetry-collector"
     pullPolicy: IfNotPresent
-    tag: "0.130.1"
+    tag: "0.127.0"
   imagePullSecrets: []
   command:
     name: "otelcol"
     ## Keep this feature gate disabled to preserve our metric naming convention
-    ## Commented out with 0.130.1 https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26488
-    # extraArgs: ["--feature-gates=-pkg.translator.prometheus.NormalizeName"]
+    extraArgs: ["--feature-gates=-pkg.translator.prometheus.NormalizeName"]
   serviceAccount:
     create: false
     annotations: {}


### PR DESCRIPTION
Revert otel config until the back-end supports direct otlp or we support different metric naming patterns. The changes in 0.130.1 do not support the current metric naming patterns. 

#67