### PR TITLE
Update RunWhen Local configuration and templates to enable upload settings when runner is active. Adjusted comments for clarity and corrected mandatory fields in values.yaml. Enhanced workspace-builder labels in templates for better identification.

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runwhen-local
 description: The RunWhen Local Helm Chart - Private runners powering Agentic AI
 type: application
-version: 0.5.0
-appVersion: "0.10.51"
+version: 0.5.1
+appVersion: "0.10.55"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   - name: opentelemetry-collector

--- a/charts/runwhen-local/templates/_helpers.tpl
+++ b/charts/runwhen-local/templates/_helpers.tpl
@@ -51,16 +51,23 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Workspace-builder component labels and selectors
+Workspace-builder component labels and selectors.
+app.kubernetes.io/name uses the workspace-builder fullname (e.g. runwhen-local-workspace-builder).
+A pre-upgrade hook deletes the old Deployment so the immutable selector change is safe.
 */}}
 {{- define "runwhen-local.workspaceBuilderSelectorLabels" -}}
-{{ include "runwhen-local.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "runwhen-local.workspaceBuilderFullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: workspace-builder
 {{- end }}
 
 {{- define "runwhen-local.workspaceBuilderLabels" -}}
-{{ include "runwhen-local.labels" . }}
-app.kubernetes.io/component: workspace-builder
+helm.sh/chart: {{ include "runwhen-local.chart" . }}
+{{ include "runwhen-local.workspaceBuilderSelectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*

--- a/charts/runwhen-local/templates/workspace-builder-deployment.yaml
+++ b/charts/runwhen-local/templates/workspace-builder-deployment.yaml
@@ -1,4 +1,19 @@
 {{- $wb := include "runwhen-local.resolveWorkspaceBuilder" . | fromYaml -}}
+{{- if and .Values.runner.enabled (not $wb.autoRun.uploadEnabled) -}}
+  {{- $_ := set $wb.autoRun "uploadEnabled" true -}}
+{{- end -}}
+{{- if and .Values.runner.enabled (not $wb.uploadInfo.secretProvided.enabled) -}}
+  {{- $_ := set $wb.uploadInfo.secretProvided "enabled" true -}}
+  {{- if not $wb.uploadInfo.secretProvided.secretName -}}
+    {{- $_ := set $wb.uploadInfo.secretProvided "secretName" "uploadinfo" -}}
+  {{- end -}}
+  {{- if not $wb.uploadInfo.secretProvided.secretKey -}}
+    {{- $_ := set $wb.uploadInfo.secretProvided "secretKey" "uploadInfo.yaml" -}}
+  {{- end -}}
+  {{- if not $wb.uploadInfo.secretProvided.secretPath -}}
+    {{- $_ := set $wb.uploadInfo.secretProvided "secretPath" "uploadInfo.yaml" -}}
+  {{- end -}}
+{{- end -}}
 {{- if $wb.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,7 +45,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: workspace-builder
           {{- include "runwhen-local.containerSecurityContext" . | nindent 10 }}
           image: "{{ ($wb.image.registry | default .Values.registryOverride)| default "ghcr.io" }}/{{ $wb.image.repository | default "runwhen-contrib/runwhen-local" }}:{{ $wb.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ $wb.image.pullPolicy }}

--- a/charts/runwhen-local/templates/workspace-builder-pre-upgrade-hook.yaml
+++ b/charts/runwhen-local/templates/workspace-builder-pre-upgrade-hook.yaml
@@ -1,0 +1,89 @@
+{{- $wb := include "runwhen-local.resolveWorkspaceBuilder" . | fromYaml -}}
+{{- if $wb.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runwhen-local.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runwhen-local.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runwhen-local.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "runwhen-local.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 60
+  template:
+    metadata:
+      labels:
+        {{- include "runwhen-local.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "runwhen-local.fullname" . }}-pre-upgrade
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: pre-upgrade
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Deleting workspace-builder Deployment to allow selector label migration..."
+              kubectl delete deployment \
+                {{ include "runwhen-local.workspaceBuilderFullname" . }} \
+                --namespace={{ .Release.Namespace }} \
+                --ignore-not-found=true
+              echo "Done. Helm will recreate the Deployment with updated selectors."
+{{- end }}

--- a/charts/runwhen-local/values.yaml
+++ b/charts/runwhen-local/values.yaml
@@ -200,12 +200,13 @@ workspaceBuilder:
       # secretPath: kubeconfig
 
   ### RunWhen Local Runtime Configuration
-  # autoRun: start discovery on deployment, and re-run discovery evey discoveryInterval seconds
+  # autoRun: start discovery on deployment, and re-run discovery every discoveryInterval seconds
   # also supports upload configuration for continuous updates of RunWhen Platform Workspace
-  # upload is disabled by default; requires a valid uploadInfo.yaml
+  # Note: when runner.enabled is true, uploadEnabled is automatically set to true
+  # and the uploadInfo secret defaults to "uploadinfo" (can still be overridden below)
   autoRun:
     discoveryInterval: 14400                 # seconds to wait until a new discovery
-    uploadEnabled: false                     # upload configuration to RunWhen Platform
+    uploadEnabled: false                     # auto-enabled when runner.enabled is true
     uploadMergeMode: "keep-uploaded"         # 'keep-uploaded' or 'keep-existing'
 
 
@@ -236,14 +237,16 @@ workspaceBuilder:
   # The upload configuration applies only to users to leverage RunWhen Local as an
   # onboarding tool into RunWhen Platform (https://docs.runwhen.com/public/v/runwhen-local/user-guide/features/upload-to-runwhen-platform for more details)
   # When uploading discovered resources and configuration information to RunWhen Platform,
-  # workspaceName, token, workspaceOwnerEmail, defaultLocation and papiURL are mandtatory
-  # can can be obtained immediately after creating a RunWhen Platform workspace.
+  # workspaceName, token, workspaceOwnerEmail, defaultLocation and papiURL are mandatory
+  # and can be obtained immediately after creating a RunWhen Platform workspace.
+  # Note: when runner.enabled is true, this is automatically enabled with the defaults
+  # shown below. Set explicitly to override.
   uploadInfo:
     secretProvided:
       enabled: false
-      # secretName: "uploadinfo"
-      # secretKey: uploadInfo.yaml
-      # secretPath: uploadInfo.yaml
+      secretName: "uploadinfo"
+      secretKey: uploadInfo.yaml
+      secretPath: uploadInfo.yaml
 
 
   ## workspaceInfo


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes Kubernetes label selectors for the `workspace-builder` Deployment (immutable), requiring a pre-upgrade hook that deletes the Deployment during upgrades; this can cause brief downtime or disruption if misconfigured. Also auto-enables upload-related config when `runner.enabled` is true, which could change runtime behavior for existing installs.
> 
> **Overview**
> Bumps the `runwhen-local` chart to `0.5.1` (app `0.10.55`) and updates the `workspace-builder` Deployment labeling to use a component-specific `app.kubernetes.io/name` (matching `*-workspace-builder`) plus refreshed chart/version/managed-by labels.
> 
> To safely migrate the now-immutable selector labels, adds a Helm *pre-upgrade* hook (SA/Role/RoleBinding + Job running `kubectl`) that deletes the existing `workspace-builder` Deployment so Helm can recreate it with the new selectors.
> 
> When `runner.enabled` is true, the `workspace-builder` template now auto-enables `autoRun.uploadEnabled` and defaults `uploadInfo.secretProvided` to `enabled` with `uploadinfo`/`uploadInfo.yaml` settings; `values.yaml` comments are updated accordingly and a few doc typos are corrected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ee395eaf28c72cd07d4a34d88244b9560ba1180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->