### PR TITLE
version bump

### DIFF
--- a/charts/runwhen-local/Chart.yaml
+++ b/charts/runwhen-local/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: runwhen-local
 description: The RunWhen Local Helm Chart - Private runners powering Agentic AI
 type: application
-version: 0.6.0
-appVersion: "0.11.0"
+version: 0.6.1
+appVersion: "0.11.3"
 icon: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/runwhen_icon.png
 dependencies:
   - name: opentelemetry-collector


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only chart version bump with no changes to deployments, dependencies, or application logic.
> 
> **Overview**
> Bumps the **runwhen-local** Helm chart release metadata only: chart `version` **0.6.0 → 0.6.1** and `appVersion` **0.11.0 → 0.11.3**. No template, dependency, or runtime configuration changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053ef082e2e91ea8c78d658494777e5673b79f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->